### PR TITLE
Fix a few C4100 warnings (optimized/release builds)

### DIFF
--- a/source/nicegraf_util.c
+++ b/source/nicegraf_util.c
@@ -141,6 +141,7 @@ ngf_error ngf_util_create_layout(uint32_t **stage_layouts,
                                  ngf_pipeline_layout_info *result) {
   assert(stage_layouts);
   assert(result && nstages);
+  if( !stage_layouts || !nstages || !result ) abort();
   /*ngf_descriptor_set_layout **dsls = NULL;
   result->descriptors_layouts = NULL;
   result->ndescriptors_layouts = 0u;


### PR DESCRIPTION
Temporary solution to mute "unreferenced formal parameter" warning.
//assert() has no effect in opt/release builds