### PR TITLE
Fixed 2 small compile errors on clang

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,3 +51,5 @@ set_target_properties(ngf_tests PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_CURRENT_LIST_DIR}")
 set_target_properties(ngf_tests PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_CURRENT_LIST_DIR}")
+set_target_properties(ngf_tests PROPERTIES
+    CXX_STANDARD 17)

--- a/tests/dynamic_array_test.cpp
+++ b/tests/dynamic_array_test.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Populate a dynamic array", "[dynarr_populate]") {
   std::vector<point> check_array;
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_real_distribution<> d(0.0, 1.0);
+  std::uniform_real_distribution<float> d(0.0, 1.0);
   _NGF_DARRAY_RESET(pt_array, 100u);
   uint32_t ntests = pt_array.capacity + 1000u;
   for (uint32_t i = 0u; i < ntests; ++i) {


### PR DESCRIPTION
Hello! I found this library while searching for some libs and I was curious. I had 2 errors while compiling the tests on clang (clang-1001.0.46.4) on macOS 10.14.4

the first set of errors was because of the use of auto on some function return types

```
/Users/underdisk/git/nicegraf/tests/../third_party/catch/catch.hpp:568:9: error: 'auto' not allowed in function return type
```

I fixed that by enabling C++17 in the CMakeLists.txt of nicegraf-tests

the second set of errors was because of an implicit type cast that clang did not resolve correctly. i fixed it by adding a float type in the std::uniform_real_distribution of dynamic_array_test.cpp

I don't know much of the codebase so I hope this is a useful PR

everything seems to be OK

`All tests passed (64588 assertions in 5 test cases)` 