### PR TITLE
[internal] disable msvc warning 4232: address of dllimport is not static

### DIFF
--- a/source/metadata_parser.c
+++ b/source/metadata_parser.c
@@ -32,10 +32,20 @@
   #include <arpa/inet.h>
 #endif
 
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // address of dllimport is not static, identity not guaranteed
+  #pragma warning(disable:4232)
+#endif
+
 static const ngf_plmd_alloc_callbacks stdlib_alloc = {
   .allocate = malloc,
   .deallocate = free
 };
+
+#ifdef _MSC_VER
+  #pragma warning( pop )
+#endif
 
 struct ngf_plmd {
   uint8_t *raw_data;

--- a/source/stack_alloc.c
+++ b/source/stack_alloc.c
@@ -35,7 +35,7 @@ void* ngfi_sa_alloc(ngfi_sa *allocator, size_t nbytes) {
   assert(allocator);
   void           *result             = NULL;
   const ptrdiff_t consumed_capacity  = allocator->ptr - allocator->data;
-  const ptrdiff_t available_capacity = allocator->capacity - consumed_capacity;
+  const ptrdiff_t available_capacity = (ptrdiff_t)allocator->capacity - consumed_capacity;
   if (available_capacity >= (ptrdiff_t)nbytes) {
     result = allocator->ptr;
     allocator->ptr += nbytes;


### PR DESCRIPTION
fix clang warning: implicit conversion from unsigned to ptrdiff_t