### PR TITLE
check handle before calling encoder_end in xfer/render encoder wrappers

### DIFF
--- a/include/nicegraf_wrappers.h
+++ b/include/nicegraf_wrappers.h
@@ -129,7 +129,7 @@ class render_encoder {
   }
 
   ~render_encoder() {
-    ngf_render_encoder_end(enc_);
+    if (enc_.__handle) ngf_render_encoder_end(enc_);
   }
 
   render_encoder(render_encoder&& other) {
@@ -160,7 +160,7 @@ class xfer_encoder {
   }
 
   ~xfer_encoder() {
-    ngf_xfer_encoder_end(enc_);
+    if (enc_.__handle) ngf_xfer_encoder_end(enc_);
   }
 
   xfer_encoder(xfer_encoder&& other) {


### PR DESCRIPTION
Fixes an issue of calling xxx_encoder_end on invalidated object caused by a move assignment