### PR TITLE
Feature/sample count capability

### DIFF
--- a/include/nicegraf-util.h
+++ b/include/nicegraf-util.h
@@ -93,6 +93,19 @@ static inline size_t ngf_util_align_size(size_t value, size_t alignment) {
     return value + (m > 0 ? (alignment - m) : 0u);
 }
 
+/**
+ * \ingroup ngf_util
+ *
+ * Returns the largest sample count in a sample count bitmap
+ */
+static inline ngf_sample_count ngf_util_get_highest_sample_count(size_t counts_bitmap) {
+    size_t res = (size_t) NGF_SAMPLE_COUNT_64;
+    while ((res & counts_bitmap) == 0 && res > 1) {
+        res >>= 1;
+    }
+    return (ngf_sample_count) res;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/nicegraf-util.h
+++ b/include/nicegraf-util.h
@@ -93,19 +93,6 @@ static inline size_t ngf_util_align_size(size_t value, size_t alignment) {
     return value + (m > 0 ? (alignment - m) : 0u);
 }
 
-/**
- * \ingroup ngf_util
- *
- * Returns the largest sample count in a sample count bitmap
- */
-static inline ngf_sample_count ngf_util_get_highest_sample_count(size_t counts_bitmap) {
-    size_t res = (size_t) NGF_SAMPLE_COUNT_64;
-    while ((res & counts_bitmap) == 0 && res > 1) {
-        res >>= 1;
-    }
-    return (ngf_sample_count) res;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/nicegraf.h
+++ b/include/nicegraf.h
@@ -112,152 +112,6 @@ extern "C" {
 #endif
 
 /**
- * This is a special value used within the \ref ngf_device_capabilities structure
- * to indicate that a limit value (i.e. max texture size) is not known or not
- * relevant for the current backend.
- */
-#define NGF_DEVICE_LIMIT_UNKNOWN (~0u)
-
-/**
- * @struct ngf_device_capabilities
- * \ingroup ngf
- * Contains information about various device features, limits, etc. Clients
- * shouldn't instantiate this structure. See \ref ngf_get_device_capabilities.
- */
-typedef struct ngf_device_capabilities {
-  /**
-   * When binding uniform buffers, the specified offset must be
-   * a multiple of this number.
-   */
-  size_t uniform_buffer_offset_alignment;
-
-  /**
-   * When binding a uniform buffer, the specified range must not exceed
-   * this value.
-   */
-  size_t max_uniform_buffer_range;
-
-  /**
-   * When binding texel buffers, the specified offset must be
-   * a multiple of this number.
-   */
-  size_t texel_buffer_offset_alignment;
-
-  /**
-   * The maximum allowed number of vertex attributes per pipeline.
-   */
-  size_t max_vertex_input_attributes_per_pipeline;
-
-  /**
-   * The maximum allowed number of sampled images (textures) per single
-   * shader stage. Descriptors with type \ref NGF_DESCRIPTOR_IMAGE_AND_SAMPLER
-   * and \ref NGF_DESCRIPTOR_TEXEL_BUFFER do count against this limit.
-   */
-  size_t max_sampled_images_per_stage;
-
-  /**
-   * The maximum allowed number of sampler objects per single shader stage.
-   * Descriptors with type \ref NGF_DESCRIPTOR_IMAGE_AND_SAMPLER do count against
-   * this limit.
-   */
-  size_t max_samplers_per_stage;
-
-  /**
-   * The maximum allowed number of uniform buffers per single shader stage.
-   */
-  size_t max_uniform_buffers_per_stage;
-
-  /**
-   * This is the maximum number of _components_, across all inputs, for the fragment
-   * stage. "Input component" refers to the individual components of an input vector.
-   * For example, if the fragment stage has a single float4 input (vector of 4 floats),
-   * then it has 4 input components.
-   */
-  size_t max_fragment_input_components;
-
-  /**
-   * This is the maximum number of inputs for the fragment stage.
-   */
-  size_t max_fragment_inputs;
-
-  /**
-   * Maximum allowed width of a 1D image.
-   */
-  size_t max_1d_image_dimension;
-
-  /**
-   * Maximum allowed width, or height of a 2D image.
-   */
-  size_t max_2d_image_dimension;
-
-  /**
-   * Maximum allowed width, height, or depth of a 3D image.
-   */
-
-  size_t max_3d_image_dimension;
-
-  /**
-   * Maximum allowed width, or height of a cubemap.
-   */
-  size_t max_cube_image_dimension;
-
-  /**
-   * Maximum allowed number of layers in an image.
-   */
-  size_t max_image_layers;
-
-  /**
-   * Maximum number of color attachments that can be written to
-   * during a render pass.
-   */
-  size_t max_color_attachments_per_pass;
-
-  /**
-   * The maximum degree of sampler anisotropy.
-   */
-  float max_sampler_anisotropy;
-
-  /**
-   * This flag is set to `true` if the platform supports [0; 1]
-   * range for the clip-space z coordinate. nicegraf enforces clip-space
-   * z to be in this range on all backends that support it. This ensures
-   * better precision for near-field objects.
-   * See the following for an in-depth explanation:
-   * http://web.archive.org/web/20210829130722/https://developer.nvidia.com/content/depth-precision-visualized
-   */
-  bool clipspace_z_zero_to_one;
-
-  /**
-   * This flag is set to true if the device supports cubemap arrays.
-   */
-  bool cubemap_arrays_supported;
-
-  /**
-   * Bitmap representing multisample count support for framebuffer color attachments
-   * For example, (framebuffer_color_sample_counts & 16) indicates support for 16 samples
-   */
-  size_t framebuffer_color_sample_counts;
-
-  /**
-   * Bitmap representing multisample count support for framebuffer depth attachments
-   * For example, (framebuffer_depth_sample_counts & 16) indicates support for 16 samples
-   */
-  size_t framebuffer_depth_sample_counts;
-
-  /**
-   * Bitmap representing multisample count support for color textures
-   * For example, (texture_color_sample_counts & 16) indicates support for 16 samples
-   */
-  size_t texture_color_sample_counts;
-
-  /**
-   * Bitmap representing multisample count support for depth textures
-   * For example, (texture_depth_sample_counts & 16) indicates support for 16 samples
-   */
-  size_t texture_depth_sample_counts;
-} ngf_device_capabilities;
-
-/**
  * @enum ngf_diagnostic_log_verbosity
  * \ingroup ngf
  * Verbosity levels for the diagnostic message log.
@@ -369,30 +223,6 @@ typedef enum ngf_device_performance_tier {
 
   NGF_DEVICE_PERFORMANCE_TIER_COUNT
 } ngf_device_performance_tier;
-
-/**
- * Maximum length of a device's name.
- * \ingroup ngf
- */
-#define NGF_DEVICE_NAME_MAX_LENGTH (256u)
-
-/**
- * @struct ngf_device
- * Information about a rendering device.
- * See also: \ref ngf_get_device_list
- * \ingroup ngf
- */
-typedef struct ngf_device {
-  ngf_device_performance_tier performance_tier; /**< Device's performance tier. */
-  ngf_device_handle           handle; /**< A handle to be passed to \ref ngf_initialize. */
-
-  /**
-   * A string associated with the device. This is _not_ guaranteed to be unique per device.
-   */
-  char name[NGF_DEVICE_NAME_MAX_LENGTH];
-
-  ngf_device_capabilities capabilities; /**< Device capabilities and limits. */
-} ngf_device;
 
 /**
  * @struct ngf_init_info
@@ -2522,6 +2352,200 @@ struct ngf_sync_xfer_resource {
   ngf_xfer_encoder   encoder; /** < The encoder to wait on. */
   ngf_sync_resource_ref resource; /** < Reference to the (sub)resource being accessed. */
 };
+
+/**
+ * This is a special value used within the \ref ngf_device_capabilities structure
+ * to indicate that a limit value (i.e. max texture size) is not known or not
+ * relevant for the current backend.
+ */
+#define NGF_DEVICE_LIMIT_UNKNOWN (~0u)
+
+/**
+ * @struct ngf_device_capabilities
+ * \ingroup ngf
+ * Contains information about various device features, limits, etc. Clients
+ * shouldn't instantiate this structure. See \ref ngf_get_device_capabilities.
+ */
+typedef struct ngf_device_capabilities {
+  /**
+   * When binding uniform buffers, the specified offset must be
+   * a multiple of this number.
+   */
+  size_t uniform_buffer_offset_alignment;
+
+  /**
+   * When binding a uniform buffer, the specified range must not exceed
+   * this value.
+   */
+  size_t max_uniform_buffer_range;
+
+  /**
+   * When binding texel buffers, the specified offset must be
+   * a multiple of this number.
+   */
+  size_t texel_buffer_offset_alignment;
+
+  /**
+   * The maximum allowed number of vertex attributes per pipeline.
+   */
+  size_t max_vertex_input_attributes_per_pipeline;
+
+  /**
+   * The maximum allowed number of sampled images (textures) per single
+   * shader stage. Descriptors with type \ref NGF_DESCRIPTOR_IMAGE_AND_SAMPLER
+   * and \ref NGF_DESCRIPTOR_TEXEL_BUFFER do count against this limit.
+   */
+  size_t max_sampled_images_per_stage;
+
+  /**
+   * The maximum allowed number of sampler objects per single shader stage.
+   * Descriptors with type \ref NGF_DESCRIPTOR_IMAGE_AND_SAMPLER do count against
+   * this limit.
+   */
+  size_t max_samplers_per_stage;
+
+  /**
+   * The maximum allowed number of uniform buffers per single shader stage.
+   */
+  size_t max_uniform_buffers_per_stage;
+
+  /**
+   * This is the maximum number of _components_, across all inputs, for the fragment
+   * stage. "Input component" refers to the individual components of an input vector.
+   * For example, if the fragment stage has a single float4 input (vector of 4 floats),
+   * then it has 4 input components.
+   */
+  size_t max_fragment_input_components;
+
+  /**
+   * This is the maximum number of inputs for the fragment stage.
+   */
+  size_t max_fragment_inputs;
+
+  /**
+   * Maximum allowed width of a 1D image.
+   */
+  size_t max_1d_image_dimension;
+
+  /**
+   * Maximum allowed width, or height of a 2D image.
+   */
+  size_t max_2d_image_dimension;
+
+  /**
+   * Maximum allowed width, height, or depth of a 3D image.
+   */
+
+  size_t max_3d_image_dimension;
+
+  /**
+   * Maximum allowed width, or height of a cubemap.
+   */
+  size_t max_cube_image_dimension;
+
+  /**
+   * Maximum allowed number of layers in an image.
+   */
+  size_t max_image_layers;
+
+  /**
+   * Maximum number of color attachments that can be written to
+   * during a render pass.
+   */
+  size_t max_color_attachments_per_pass;
+
+  /**
+   * The maximum degree of sampler anisotropy.
+   */
+  float max_sampler_anisotropy;
+
+  /**
+   * This flag is set to `true` if the platform supports [0; 1]
+   * range for the clip-space z coordinate. nicegraf enforces clip-space
+   * z to be in this range on all backends that support it. This ensures
+   * better precision for near-field objects.
+   * See the following for an in-depth explanation:
+   * http://web.archive.org/web/20210829130722/https://developer.nvidia.com/content/depth-precision-visualized
+   */
+  bool clipspace_z_zero_to_one;
+
+  /**
+   * This flag is set to true if the device supports cubemap arrays.
+   */
+  bool cubemap_arrays_supported;
+
+  /**
+   * Bitmap representing multisample count support for framebuffer color attachments
+   * For example, (framebuffer_color_sample_counts & 16) indicates support for 16 samples
+   */
+  size_t framebuffer_color_sample_counts;
+
+  /**
+   * The highest supported sample count for framebuffer color attachments.
+   * This value is derived from \ref framebuffer_color_sample_counts.
+   */
+  ngf_sample_count max_supported_framebuffer_color_sample_count;
+
+  /**
+   * Bitmap representing multisample count support for framebuffer depth attachments
+   * For example, (framebuffer_depth_sample_counts & 16) indicates support for 16 samples
+   */
+  size_t framebuffer_depth_sample_counts;
+
+  /**
+   * The highest supported sample count for framebuffer depth attachments.
+   * This value is derived from \ref framebuffer_depth_sample_counts.
+   */
+  ngf_sample_count max_supported_framebuffer_depth_sample_count;
+
+  /**
+   * Bitmap representing multisample count support for color textures
+   * For example, (texture_color_sample_counts & 16) indicates support for 16 samples
+   */
+  size_t texture_color_sample_counts;
+
+  /**
+   * The highest supported sample count for color textures.
+   * This value is derived from \ref texture_color_sample_counts.
+   */
+  ngf_sample_count max_supported_texture_color_sample_count;
+
+  /**
+   * Bitmap representing multisample count support for depth textures
+   * For example, (texture_depth_sample_counts & 16) indicates support for 16 samples
+   */
+  size_t texture_depth_sample_counts;
+
+  /**
+   * The highest supported sample count for depth textures.
+   * This value is derived from \ref texture_depth_sample_counts.
+   */
+  ngf_sample_count max_supported_texture_depth_sample_count;
+} ngf_device_capabilities;
+
+/**
+ * Maximum length of a device's name.
+ * \ingroup ngf
+ */
+#define NGF_DEVICE_NAME_MAX_LENGTH (256u)
+
+/**
+ * @struct ngf_device
+ * Information about a rendering device.
+ * See also: \ref ngf_get_device_list
+ * \ingroup ngf
+ */
+typedef struct ngf_device {
+  ngf_device_performance_tier performance_tier; /**< Device's performance tier. */
+  ngf_device_handle           handle; /**< A handle to be passed to \ref ngf_initialize. */
+
+  /**
+   * A string associated with the device. This is _not_ guaranteed to be unique per device.
+   */
+  char name[NGF_DEVICE_NAME_MAX_LENGTH];
+
+  ngf_device_capabilities capabilities; /**< Device capabilities and limits. */
+} ngf_device;
 
 #ifdef _MSC_VER
 #pragma endregion

--- a/include/nicegraf.h
+++ b/include/nicegraf.h
@@ -231,6 +231,30 @@ typedef struct ngf_device_capabilities {
    * This flag is set to true if the device supports cubemap arrays.
    */
   bool cubemap_arrays_supported;
+
+  /**
+   * Bitmap representing multisample count support for framebuffer color attachments
+   * For example, (framebuffer_color_sample_counts & 16) indicates support for 16 samples
+   */
+  size_t framebuffer_color_sample_counts;
+
+  /**
+   * Bitmap representing multisample count support for framebuffer depth attachments
+   * For example, (framebuffer_depth_sample_counts & 16) indicates support for 16 samples
+   */
+  size_t framebuffer_depth_sample_counts;
+
+  /**
+   * Bitmap representing multisample count support for color textures
+   * For example, (texture_color_sample_counts & 16) indicates support for 16 samples
+   */
+  size_t texture_color_sample_counts;
+
+  /**
+   * Bitmap representing multisample count support for depth textures
+   * For example, (texture_depth_sample_counts & 16) indicates support for 16 samples
+   */
+  size_t texture_depth_sample_counts;
 } ngf_device_capabilities;
 
 /**

--- a/samples/common/main.cpp
+++ b/samples/common/main.cpp
@@ -179,12 +179,11 @@ int NGF_SAMPLES_COMMON_MAIN(int, char**) {
 
   /**
    * Configure the swapchain and create a nicegraf context.
-   * Use an sRGB color attachment and a 32-bit float depth attachment. Enable MSAA with 8 samples
-   * per pixel if supported; otherwise 4 samples is supported on all MacOS devices.
+   * Use an sRGB color attachment and a 32-bit float depth attachment. Enable MSAA with
+   * the highest supported framebuffer sample count.
    */
-  const ngf_sample_count   main_render_target_sample_count =
-    (ngf_get_device_capabilities()->texture_color_sample_counts & 8) ?
-    NGF_SAMPLE_COUNT_8 : NGF_SAMPLE_COUNT_4;
+  const size_t samples_bitmap = ngf_get_device_capabilities()->framebuffer_color_sample_counts;
+  const ngf_sample_count main_render_target_sample_count = ngf_util_get_highest_sample_count(samples_bitmap);
   const ngf_swapchain_info swapchain_info                  = {
                        .color_format  = NGF_IMAGE_FORMAT_BGRA8_SRGB,
                        .depth_format  = NGF_IMAGE_FORMAT_DEPTH32,

--- a/samples/common/main.cpp
+++ b/samples/common/main.cpp
@@ -180,9 +180,11 @@ int NGF_SAMPLES_COMMON_MAIN(int, char**) {
   /**
    * Configure the swapchain and create a nicegraf context.
    * Use an sRGB color attachment and a 32-bit float depth attachment. Enable MSAA with 8 samples
-   * per pixel.
+   * per pixel if supported; otherwise 4 samples is supported on all MacOS devices.
    */
-  const ngf_sample_count   main_render_target_sample_count = NGF_SAMPLE_COUNT_8;
+  const ngf_sample_count   main_render_target_sample_count =
+    (ngf_get_device_capabilities()->texture_color_sample_counts & 8) ?
+    NGF_SAMPLE_COUNT_8 : NGF_SAMPLE_COUNT_4;
   const ngf_swapchain_info swapchain_info                  = {
                        .color_format  = NGF_IMAGE_FORMAT_BGRA8_SRGB,
                        .depth_format  = NGF_IMAGE_FORMAT_DEPTH32,

--- a/samples/common/main.cpp
+++ b/samples/common/main.cpp
@@ -182,8 +182,7 @@ int NGF_SAMPLES_COMMON_MAIN(int, char**) {
    * Use an sRGB color attachment and a 32-bit float depth attachment. Enable MSAA with
    * the highest supported framebuffer sample count.
    */
-  const size_t samples_bitmap = ngf_get_device_capabilities()->framebuffer_color_sample_counts;
-  const ngf_sample_count main_render_target_sample_count = ngf_util_get_highest_sample_count(samples_bitmap);
+  const ngf_sample_count main_render_target_sample_count = ngf_get_device_capabilities()->max_supported_framebuffer_color_sample_count;
   const ngf_swapchain_info swapchain_info                  = {
                        .color_format  = NGF_IMAGE_FORMAT_BGRA8_SRGB,
                        .depth_format  = NGF_IMAGE_FORMAT_DEPTH32,

--- a/source/ngf-common/internal.c
+++ b/source/ngf-common/internal.c
@@ -51,3 +51,11 @@ void ngfi_set_allocation_callbacks(const ngf_allocation_callbacks* callbacks) {
     NGF_ALLOC_CB = callbacks;
   }
 }
+
+ngf_sample_count ngfi_get_highest_sample_count(size_t counts_bitmap) {
+    size_t res = (size_t) NGF_SAMPLE_COUNT_64;
+    while ((res & counts_bitmap) == 0 && res > 1) {
+        res >>= 1;
+    }
+    return (ngf_sample_count) res;
+}

--- a/source/ngf-mtl/impl.mm
+++ b/source/ngf-mtl/impl.mm
@@ -869,6 +869,15 @@ static void ngfmtl_populate_ngf_device(uint32_t handle, ngf_device& ngfdev, id<M
   caps.cubemap_arrays_supported = gpu_family_idx == ngfmtl_gpufam_idx(MTLGPUFamilyCommon2) ||
                                   gpu_family_idx == ngfmtl_gpufam_idx(MTLGPUFamilyCommon3) ||
                                   gpu_family_idx >= ngfmtl_gpufam_idx(MTLGPUFamilyApple3);
+
+  caps.texture_color_sample_counts = ([mtldev supportsTextureSampleCount:1] ? 1 : 0) |
+                                     ([mtldev supportsTextureSampleCount:2] ? 2 : 0) |
+                                     ([mtldev supportsTextureSampleCount:4] ? 4 : 0) |
+                                     ([mtldev supportsTextureSampleCount:8] ? 8 : 0);
+
+  caps.texture_depth_sample_counts = caps.texture_color_sample_counts;
+  caps.framebuffer_color_sample_counts = caps.texture_color_sample_counts;
+  caps.framebuffer_depth_sample_counts = caps.texture_color_sample_counts;
 }
 
 extern "C" {

--- a/source/ngf-vk/impl.c
+++ b/source/ngf-vk/impl.c
@@ -2696,6 +2696,15 @@ ngf_error ngf_get_device_list(const ngf_device** devices, uint32_t* ndevices) {
       devcaps->framebuffer_depth_sample_counts = vkdevlimits->framebufferDepthSampleCounts;
       devcaps->texture_color_sample_counts     = vkdevlimits->sampledImageColorSampleCounts;
       devcaps->texture_depth_sample_counts     = vkdevlimits->sampledImageDepthSampleCounts;
+      
+      devcaps->max_supported_framebuffer_color_sample_count =
+        ngfi_get_highest_sample_count(devcaps->framebuffer_color_sample_counts);
+      devcaps->max_supported_framebuffer_depth_sample_count =
+        ngfi_get_highest_sample_count(devcaps->framebuffer_depth_sample_counts);
+      devcaps->max_supported_texture_color_sample_count =
+        ngfi_get_highest_sample_count(devcaps->texture_color_sample_counts);
+      devcaps->max_supported_texture_depth_sample_count =
+        ngfi_get_highest_sample_count(devcaps->texture_depth_sample_counts);
     }
 ngf_enumerate_devices_cleanup:
     if (tmp_instance != VK_NULL_HANDLE) { destroy_vk_instance(tmp_instance, NULL); }

--- a/source/ngf-vk/impl.c
+++ b/source/ngf-vk/impl.c
@@ -751,6 +751,7 @@ static VkPipelineStageFlags get_vk_buffer_pipeline_stage_flags(ngf_buffer buf) {
 #pragma region internal_funcs
 
 void ngfi_set_allocation_callbacks(const ngf_allocation_callbacks* callbacks);
+ngf_sample_count ngfi_get_highest_sample_count(size_t counts_bitmap);
 
 // Handler for messages from validation layers, etc.
 // All messages are forwarded to the user-provided debug callback.

--- a/source/ngf-vk/impl.c
+++ b/source/ngf-vk/impl.c
@@ -2681,16 +2681,20 @@ ngf_error ngf_get_device_list(const ngf_device** devices, uint32_t* ndevices) {
       devcaps->max_fragment_input_components = vkdevlimits->maxFragmentInputComponents;
       devcaps->max_fragment_inputs =
           (devcaps->max_fragment_input_components) / 4; /* as per vk spec. */
-      devcaps->max_1d_image_dimension         = vkdevlimits->maxImageDimension1D;
-      devcaps->max_2d_image_dimension         = vkdevlimits->maxImageDimension2D;
-      devcaps->max_3d_image_dimension         = vkdevlimits->maxImageDimension3D;
-      devcaps->max_cube_image_dimension       = vkdevlimits->maxImageDimensionCube;
-      devcaps->max_image_layers               = vkdevlimits->maxImageArrayLayers;
-      devcaps->max_color_attachments_per_pass = vkdevlimits->maxColorAttachments;
-      devcaps->max_uniform_buffers_per_stage  = vkdevlimits->maxPerStageDescriptorUniformBuffers;
-      devcaps->max_sampler_anisotropy         = vkdevlimits->maxSamplerAnisotropy;
-      devcaps->max_uniform_buffer_range       = vkdevlimits->maxUniformBufferRange;
-      devcaps->cubemap_arrays_supported       = dev_features.imageCubeArray;
+      devcaps->max_1d_image_dimension          = vkdevlimits->maxImageDimension1D;
+      devcaps->max_2d_image_dimension          = vkdevlimits->maxImageDimension2D;
+      devcaps->max_3d_image_dimension          = vkdevlimits->maxImageDimension3D;
+      devcaps->max_cube_image_dimension        = vkdevlimits->maxImageDimensionCube;
+      devcaps->max_image_layers                = vkdevlimits->maxImageArrayLayers;
+      devcaps->max_color_attachments_per_pass  = vkdevlimits->maxColorAttachments;
+      devcaps->max_uniform_buffers_per_stage   = vkdevlimits->maxPerStageDescriptorUniformBuffers;
+      devcaps->max_sampler_anisotropy          = vkdevlimits->maxSamplerAnisotropy;
+      devcaps->max_uniform_buffer_range        = vkdevlimits->maxUniformBufferRange;
+      devcaps->cubemap_arrays_supported        = dev_features.imageCubeArray;
+      devcaps->framebuffer_color_sample_counts = vkdevlimits->framebufferColorSampleCounts;
+      devcaps->framebuffer_depth_sample_counts = vkdevlimits->framebufferDepthSampleCounts;
+      devcaps->texture_color_sample_counts     = vkdevlimits->sampledImageColorSampleCounts;
+      devcaps->texture_depth_sample_counts     = vkdevlimits->sampledImageDepthSampleCounts;
     }
 ngf_enumerate_devices_cleanup:
     if (tmp_instance != VK_NULL_HANDLE) { destroy_vk_instance(tmp_instance, NULL); }


### PR DESCRIPTION
Add to `ngf_device_capabilities`, four new variables which are bitmaps representing support for multisample sample counts for
- framebuffer color attachments
- framebuffer depth attachments
- sampled color textures
- sampled depth textures

On Vulkan, they can be different values. On Metal devices, these values are all the same:
https://developer.apple.com/documentation/metal/mtldevice/1433355-supportstexturesamplecount

Add a utility function to extract the largest `ngf_sample_count` value from the bitmap values.

Change the samples main function to use the highest supported sample count.