### PR TITLE
[cmake] Updated cmake minimum version to ^3.23.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ]]
 
-cmake_minimum_required(VERSION 3.14.0)
+cmake_minimum_required(VERSION 3.23.3)
 project(nicegraf)
 
 


### PR DESCRIPTION
Updated cmake minimum version to 3.23.3 or higher. `builld.sh` fails on macOS venture related to identity issues for singing a binary, leading to issue recognizing CC and CXX variables and complete fail. Tested on:
* cmake-3.23.0 - bad
* cmake-3.23.1 - bad
* cmake-3.23.2 - bad
* cmake-3.23.3 - good
* cmake-3.23.5 - good