### PR TITLE
Adding RenderDoc support to samples

### DIFF
--- a/source/ngf-vk/impl.c
+++ b/source/ngf-vk/impl.c
@@ -2732,7 +2732,10 @@ ngf_error ngf_initialize(const ngf_init_info* init_info) {
       if (!RENDERDOC_GetAPI(eRENDERDOC_API_Version_1_6_0, (void**)&_renderdoc.api)) {
         return NGF_ERROR_OBJECT_CREATION_FAILED;
       }
-      _renderdoc.api->SetCaptureFilePathTemplate(init_info->renderdoc_info->renderdoc_destination_template);
+      if (init_info->renderdoc_info->renderdoc_destination_template) {
+        _renderdoc.api->SetCaptureFilePathTemplate(
+            init_info->renderdoc_info->renderdoc_destination_template);
+      }
       _renderdoc.is_capturing_next_frame = false;
     }
   }


### PR DESCRIPTION
Users can now perform captures in nicegraf samples provided they edit the `ngf_renderdoc_info` struct in source/common/main.cpp with a valid path to their RenderDoc library. Captures can be taken by pressing the "C" key while the sample is running.