### PR TITLE
[mtl] make host readable/writeable buffers use the shared storage mode

### DIFF
--- a/source/ngf-mtl/impl.mm
+++ b/source/ngf-mtl/impl.mm
@@ -1646,9 +1646,6 @@ void ngf_buffer_flush_range(
     [[maybe_unused]] ngf_buffer buf,
     [[maybe_unused]] size_t     offset,
     [[maybe_unused]] size_t     size) NGF_NOEXCEPT {
-#if TARGET_OS_OSX
-  [buf->mtl_buffer didModifyRange:NSMakeRange(buf->mapped_offset + offset, size)];
-#endif
 }
 
 void ngf_buffer_unmap(ngf_buffer) NGF_NOEXCEPT {

--- a/source/ngf-mtl/impl.mm
+++ b/source/ngf-mtl/impl.mm
@@ -1570,17 +1570,13 @@ void ngf_destroy_compute_pipeline(ngf_compute_pipeline pipe) NGF_NOEXCEPT {
 
 id<MTLBuffer> ngfmtl_create_buffer(const ngf_buffer_info& info) {
   MTLResourceOptions options         = 0u;
-  MTLResourceOptions managed_storage = 0u;
-#if TARGET_OS_OSX
-  managed_storage = MTLResourceStorageModeManaged;
-#endif
   switch (info.storage_type) {
   case NGF_BUFFER_STORAGE_HOST_READABLE:
   case NGF_BUFFER_STORAGE_HOST_READABLE_WRITEABLE:
-    options = MTLResourceCPUCacheModeDefaultCache | managed_storage;
+    options = MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared;
     break;
   case NGF_BUFFER_STORAGE_HOST_WRITEABLE:
-    options = MTLResourceCPUCacheModeWriteCombined | managed_storage;
+    options = MTLResourceCPUCacheModeWriteCombined | MTLResourceStorageModeShared;
     break;
   case NGF_BUFFER_STORAGE_PRIVATE:
     options = MTLResourceStorageModePrivate;


### PR DESCRIPTION
make ngf_buffer_flush_range a no-op