### PR TITLE
Add userdata pointer to allocation callbacks

### DIFF
--- a/include/nicegraf.h
+++ b/include/nicegraf.h
@@ -202,13 +202,18 @@ typedef struct ngf_allocation_callbacks {
    * The starting address of the allocated region shall have the largest alignment for the
    * target platform.
    */
-  void* (*allocate)(size_t obj_size, size_t nobjs);
+  void* (*allocate)(size_t obj_size, size_t nobjs, void* userdata);
 
   /**
    * This callback shall free a region allocated by the custom allocator. The count
    * and size of objects in the region are supplied as additional parameters.
    */
-  void (*free)(void* ptr, size_t obj_size, size_t nobjs);
+  void (*free)(void* ptr, size_t obj_size, size_t nobjs, void* userdata);
+
+  /**
+   * An arbitrary pointer that will be passed as-is to the allocate and free callbacks.
+  */
+  void* userdata;
 } ngf_allocation_callbacks;
 
 /**

--- a/source/ngf-common/internal.c
+++ b/source/ngf-common/internal.c
@@ -36,23 +36,25 @@ ngf_diagnostic_info ngfi_diag_info = {
     .callback  = NULL};
 
 // Default allocation callbacks.
-void* ngf_default_alloc(size_t obj_size, size_t nobjs) {
+void* ngf_default_alloc(size_t obj_size, size_t nobjs, void* userdata) {
+  NGFI_IGNORE_VAR(userdata);
   pthread_mutex_lock(&ngfi_sys_alloc_stats.mut);
   ngfi_sys_alloc_stats.allocated_mem += obj_size * nobjs;
   pthread_mutex_unlock(&ngfi_sys_alloc_stats.mut);
   return malloc(obj_size * nobjs);
 }
 
-void ngf_default_free(void* ptr, size_t s, size_t n) {
+void ngf_default_free(void* ptr, size_t s, size_t n, void* userdata) {
   NGFI_IGNORE_VAR(s);
   NGFI_IGNORE_VAR(n);
+  NGFI_IGNORE_VAR(userdata);
   pthread_mutex_lock(&ngfi_sys_alloc_stats.mut);
   ngfi_sys_alloc_stats.allocated_mem -= s * n;
   pthread_mutex_unlock(&ngfi_sys_alloc_stats.mut);
   free(ptr);
 }
 
-const ngf_allocation_callbacks NGF_DEFAULT_ALLOC_CB = {ngf_default_alloc, ngf_default_free};
+const ngf_allocation_callbacks NGF_DEFAULT_ALLOC_CB = {ngf_default_alloc, ngf_default_free, NULL};
 
 const ngf_allocation_callbacks* NGF_ALLOC_CB = &NGF_DEFAULT_ALLOC_CB;
 

--- a/source/ngf-common/macros.h
+++ b/source/ngf-common/macros.h
@@ -33,10 +33,10 @@ extern "C" {
 extern const ngf_allocation_callbacks* NGF_ALLOC_CB;
 
 // Convenience macros for invoking custom memory allocation callbacks.
-#define NGFI_ALLOC(type)     ((type*)NGF_ALLOC_CB->allocate(sizeof(type), 1))
-#define NGFI_ALLOCN(type, n) ((type*)NGF_ALLOC_CB->allocate(sizeof(type), n))
-#define NGFI_FREE(ptr)       (NGF_ALLOC_CB->free((void*)(ptr), sizeof(*ptr), 1))
-#define NGFI_FREEN(ptr, n)   (NGF_ALLOC_CB->free((void*)(ptr), sizeof(*ptr), n))
+#define NGFI_ALLOC(type)     ((type*)NGF_ALLOC_CB->allocate(sizeof(type), 1, NGF_ALLOC_CB->userdata))
+#define NGFI_ALLOCN(type, n) ((type*)NGF_ALLOC_CB->allocate(sizeof(type), n, NGF_ALLOC_CB->userdata))
+#define NGFI_FREE(ptr)       (NGF_ALLOC_CB->free((void*)(ptr), sizeof(*ptr), 1, NGF_ALLOC_CB->userdata))
+#define NGFI_FREEN(ptr, n)   (NGF_ALLOC_CB->free((void*)(ptr), sizeof(*ptr), n, NGF_ALLOC_CB->userdata))
 
 // Macro for determining size of arrays.
 #if defined(_MSC_VER)

--- a/tests/internal-utils-tests.c
+++ b/tests/internal-utils-tests.c
@@ -48,15 +48,17 @@ static void ngft_bad_hashfn(uintptr_t key, uint32_t seed, void* out) {
 uint32_t allocs_called = 0u;
 uint32_t deallocs_called = 0u;
  
-void* ngft_counting_alloc(size_t obj_size, size_t nobjs) {
+void* ngft_counting_alloc(size_t obj_size, size_t nobjs, void* userdata) {
   allocs_called++;
+  (void)userdata;
   return malloc(obj_size * nobjs);
 }
 
-void ngft_counting_free(void* ptr, size_t obj_size, size_t nobjs) {
+void ngft_counting_free(void* ptr, size_t obj_size, size_t nobjs, void* userdata) {
   deallocs_called++;
   (void)obj_size;
   (void)nobjs;
+  (void)userdata;
   free(ptr);
 }
 


### PR DESCRIPTION
As described in issue https://github.com/nicebyte/nicegraf/issues/205, this adds an optional userdata pointer to `ngf_allocation_callbacks` that is passed to `allocate` and `free`.