### PR TITLE
[internal] Silence warning caused by macro expansion

### DIFF
--- a/source/ngf-common/chunk-list.h
+++ b/source/ngf-common/chunk-list.h
@@ -95,7 +95,7 @@ static inline void ngfi_chnklist_clear(ngfi_chnklist* list) {
        ptrname++)
 
 #define NGFI_CHNKLIST_FOR_EACH(chnklist, elem_type, ptrname)                                 \
-  if ((chnklist).firstchnk) NGFI_LIST_FOR_EACH(&(chnklist).firstchnk->clnode, ptrname##_node)    \
+  if ((chnklist).firstchnk) NGFI_LIST_FOR_EACH((ngfi_list_node*)&(chnklist).firstchnk->clnode, ptrname##_node)    \
     NGFI_CHNK_FOR_EACH(NGFI_CHNK_FROM_NODE(ptrname##_node), elem_type, ptrname)
 
 typedef struct ngfi_chnk_range {


### PR DESCRIPTION
Cast pointer to clnode as ngfi_list_node*

NGFI_CHNKLIST_FOR_EACH passes a struct member ptr to NGFI_LIST_FOR_EACH, but it can never be null, therefore null check is always true

`Address of '(cmd_buf->pending_bind_ops).firstchnk->clnode' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]` is emitted by clang and is treated as an error

For more details on how to repro check out:
https://discourse.cmake.org/t/fastbuild-clang-cl-combo-emits-warnings-which-ninja-clang-cl-combo-doesnt-emit-with-same-everything/15601