### PR TITLE
[build] use COMPILE_WARNING_AS_ERROR instead of explicit compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ]]
 
-cmake_minimum_required(VERSION 3.23.3)
+cmake_minimum_required(VERSION 3.24)
 project(nicegraf)
 
 
@@ -31,10 +31,11 @@ include("${CMAKE_CURRENT_LIST_DIR}/build-utils.cmake")
 
 # These are the compiler flags that are used on all nicegraf targets.
 if(MSVC)
-    set (NICEMAKE_COMMON_COMPILE_OPTS "/W4" "/WX")
+    set(NICEMAKE_COMMON_COMPILE_OPTS "/W4")
 else()
-	set(NICEMAKE_COMMON_COMPILE_OPTS "-Wall" "-Wconversion" "-Wno-unknown-pragmas" "-Werror" "-Wno-error=comment")
+    set(NICEMAKE_COMMON_COMPILE_OPTS "-Wall" "-Wconversion" "-Wno-unknown-pragmas" "-Wno-error=comment")
 endif()
+
 set(NICEGRAF_COMMON_DEPS nicegraf-internal)
 
 # A library with various utilities shared internally across different backends.

--- a/build-utils.cmake
+++ b/build-utils.cmake
@@ -85,6 +85,7 @@ function (nmk_target)
     if ( TGT_COPTS )
       target_compile_options(${TGT_NAME} PRIVATE ${TGT_COPTS})
     endif()
+    set_target_properties(${TGT_NAME} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
   endif()
 
   # Set output directory.


### PR DESCRIPTION
Replace hardcoded `/WX` and `-Werror` in `NICEMAKE_COMMON_COMPILE_OPTS` with the `COMPILE_WARNING_AS_ERROR` target property, set ON by `nmk_target`
Standalone builds behave the same; library users embedding nicegraf via `add_subdirectory` can now opt out per target:

	set_target_properties(nicegraf-internal nicegraf-util nicegraf-vk
		PROPERTIES COMPILE_WARNING_AS_ERROR OFF)

Requires CMake 3.24 (bumped from 3.23.3)