### PR TITLE
[build] fix missing-designated-field-initializers warning under clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,10 @@ set(CMAKE_CXX_STANDARD 20)
 include("${CMAKE_CURRENT_LIST_DIR}/build-utils.cmake")
 
 # These are the compiler flags that are used on all nicegraf targets.
-if(MSVC)
+if(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(NICEMAKE_COMMON_COMPILE_OPTS "/W4")
 else()
-    set(NICEMAKE_COMMON_COMPILE_OPTS "-Wall" "-Wconversion" "-Wno-unknown-pragmas" "-Wno-error=comment")
+    set(NICEMAKE_COMMON_COMPILE_OPTS "-Wall" "-Wconversion" "-Wno-unknown-pragmas" "-Wno-error=comment" "-Wno-unknown-warning-option" "-Wno-missing-designated-field-initializers")
 endif()
 
 set(NICEGRAF_COMMON_DEPS nicegraf-internal)

--- a/source/ngf-vk/impl.cpp
+++ b/source/ngf-vk/impl.cpp
@@ -2377,7 +2377,7 @@ ngf_error ngfvk_generic_pipeline::common_init(
   uint32_t last_set_id    = ~0u;
   for (uint32_t cur = 0u; cur < nunique_bindings;) {
     ngfvk_desc_set_layout set_layout;
-    memset(&set_layout, 0, sizeof(set_layout));
+    memset((void*)&set_layout, 0, sizeof(set_layout));
     const uint32_t current_set_id = bindings[cur].binding_data.set;
     if (last_set_id == ~0u || current_set_id - last_set_id > 1u) {
       // there is a gap in descriptor sets, fill it in with empty layouts;


### PR DESCRIPTION
fix nontrivial-memaccess warning
silence unknown-warning-option for older clang