### PR TITLE
[api,vk,mtl] add NGF_IMAGE_USAGE_TRANSIENT_ATTACHMENT

### DIFF
--- a/include/nicegraf.h
+++ b/include/nicegraf.h
@@ -1614,7 +1614,13 @@ typedef enum ngf_image_usage {
 
   /** \ingroup ngf
    * The image may be used as a source for a transfer operation. */
-  NGF_IMAGE_USAGE_XFER_SRC = 0x20
+  NGF_IMAGE_USAGE_XFER_SRC = 0x20,
+
+  /** \ingroup ngf
+   * The image is a transient attachment: produced and consumed within one render
+   * pass, kept in tile memory with no DRAM backing on tile-based GPUs (Metal
+   * memoryless, Vulkan lazily-allocated). Combine only with the ATTACHMENT bit. */
+  NGF_IMAGE_USAGE_TRANSIENT_ATTACHMENT = 0x40
 } ngf_image_usage;
 
 /**

--- a/source/ngf-mtl/impl.cpp
+++ b/source/ngf-mtl/impl.cpp
@@ -1458,7 +1458,12 @@ ngfi::maybe_ngfptr<ngf_image_t> ngf_image_t::make(const ngf_image_info& info) NG
   mtl_img_desc->setDepth(info.extent.depth);
   mtl_img_desc->setArrayLength(info.nlayers);
   mtl_img_desc->setMipmapLevelCount(info.nmips);
-  mtl_img_desc->setStorageMode(MTL::StorageModePrivate);
+  // Memoryless is only valid for attachment-only images (no sampling or storage),
+  // so fall back to Private if those bits are set alongside the transient bit.
+  const bool is_memoryless =
+      (info.usage_hint & NGF_IMAGE_USAGE_TRANSIENT_ATTACHMENT) &&
+      !(info.usage_hint & (NGF_IMAGE_USAGE_SAMPLE_FROM | NGF_IMAGE_USAGE_STORAGE));
+  mtl_img_desc->setStorageMode(is_memoryless ? MTL::StorageModeMemoryless : MTL::StorageModePrivate);
   mtl_img_desc->setSampleCount(info.sample_count);
   if (info.usage_hint & NGF_IMAGE_USAGE_ATTACHMENT) {
     mtl_img_desc->setUsage(mtl_img_desc->usage() | MTL::TextureUsageRenderTarget);

--- a/source/ngf-mtl/impl.cpp
+++ b/source/ngf-mtl/impl.cpp
@@ -1458,20 +1458,21 @@ ngfi::maybe_ngfptr<ngf_image_t> ngf_image_t::make(const ngf_image_info& info) NG
   mtl_img_desc->setDepth(info.extent.depth);
   mtl_img_desc->setArrayLength(info.nlayers);
   mtl_img_desc->setMipmapLevelCount(info.nmips);
-  // Memoryless is only valid for attachment-only images (no sampling or storage),
-  // so fall back to Private if those bits are set alongside the transient bit.
-  const bool is_memoryless =
-      (info.usage_hint & NGF_IMAGE_USAGE_TRANSIENT_ATTACHMENT) &&
-      !(info.usage_hint & (NGF_IMAGE_USAGE_SAMPLE_FROM | NGF_IMAGE_USAGE_STORAGE));
+  // Transient attachments are memoryless, which forbids shader access: honor memoryless,
+  // warn, and ignore the shader-usage bits if SAMPLE_FROM/STORAGE was also requested.
+  const bool is_memoryless = info.usage_hint & NGF_IMAGE_USAGE_TRANSIENT_ATTACHMENT;
+  if (is_memoryless && (info.usage_hint & (NGF_IMAGE_USAGE_SAMPLE_FROM | NGF_IMAGE_USAGE_STORAGE))) {
+    NGFI_DIAG_WARNING("transient/memoryless attachment cannot be shader-accessed, ignoring SAMPLE_FROM/STORAGE");
+  }
   mtl_img_desc->setStorageMode(is_memoryless ? MTL::StorageModeMemoryless : MTL::StorageModePrivate);
   mtl_img_desc->setSampleCount(info.sample_count);
   if (info.usage_hint & NGF_IMAGE_USAGE_ATTACHMENT) {
     mtl_img_desc->setUsage(mtl_img_desc->usage() | MTL::TextureUsageRenderTarget);
   }
-  if (info.usage_hint & NGF_IMAGE_USAGE_SAMPLE_FROM) {
+  if (!is_memoryless && (info.usage_hint & NGF_IMAGE_USAGE_SAMPLE_FROM)) {
     mtl_img_desc->setUsage(mtl_img_desc->usage() | MTL::TextureUsageShaderRead);
   }
-  if (info.usage_hint & NGF_IMAGE_USAGE_STORAGE) {
+  if (!is_memoryless && (info.usage_hint & NGF_IMAGE_USAGE_STORAGE)) {
     mtl_img_desc->setUsage(mtl_img_desc->usage() | MTL::TextureUsageShaderWrite);
   }
   auto image         = ngfi::unique_ptr<ngf_image_t>::make();

--- a/source/ngf-mtl/impl.cpp
+++ b/source/ngf-mtl/impl.cpp
@@ -1458,8 +1458,6 @@ ngfi::maybe_ngfptr<ngf_image_t> ngf_image_t::make(const ngf_image_info& info) NG
   mtl_img_desc->setDepth(info.extent.depth);
   mtl_img_desc->setArrayLength(info.nlayers);
   mtl_img_desc->setMipmapLevelCount(info.nmips);
-  // Transient attachments are memoryless, which forbids shader access: honor memoryless,
-  // warn, and ignore the shader-usage bits if SAMPLE_FROM/STORAGE was also requested.
   const bool is_memoryless = info.usage_hint & NGF_IMAGE_USAGE_TRANSIENT_ATTACHMENT;
   if (is_memoryless && (info.usage_hint & (NGF_IMAGE_USAGE_SAMPLE_FROM | NGF_IMAGE_USAGE_STORAGE))) {
     NGFI_DIAG_WARNING("transient/memoryless attachment cannot be shader-accessed, ignoring SAMPLE_FROM/STORAGE");

--- a/source/ngf-vk/impl.cpp
+++ b/source/ngf-vk/impl.cpp
@@ -2676,9 +2676,6 @@ ngfi::value_or_ngferr<ngfvk_alloc> ngfvk_alloc::make(const ngf_image_info& info)
       .queueFamilyIndexCount = 0,
       .pQueueFamilyIndices   = NULL,
       .initialLayout         = VK_IMAGE_LAYOUT_UNDEFINED};
-  // Prefer lazily-allocated memory for transient attachments so they need no DRAM
-  // backing on tile-based GPUs. Preferred, not required: desktops have no such
-  // memory type, so VMA falls back to device-local instead of failing.
   VmaAllocationCreateInfo vma_alloc_info = {
       .flags          = 0u,
       .usage          = VMA_MEMORY_USAGE_GPU_ONLY,

--- a/source/ngf-vk/impl.cpp
+++ b/source/ngf-vk/impl.cpp
@@ -2625,7 +2625,8 @@ ngfi::value_or_ngferr<ngfvk_alloc> ngfvk_alloc::make(const ngf_image_info& info)
   const bool is_xfer_src      = info.usage_hint & NGF_IMAGE_USAGE_XFER_SRC;
   const bool is_attachment    = info.usage_hint & NGF_IMAGE_USAGE_ATTACHMENT;
   const bool enable_auto_mips = info.usage_hint & NGF_IMAGE_USAGE_MIPMAP_GENERATION;
-  const bool is_transient     = info.usage_hint & ngfvk::global::img_usage_transient_attachment;
+  const bool is_transient     = info.usage_hint & (ngfvk::global::img_usage_transient_attachment |
+                                                   NGF_IMAGE_USAGE_TRANSIENT_ATTACHMENT);
   const bool is_depth_stencil = info.format == NGF_IMAGE_FORMAT_DEPTH16 ||
                                 info.format == NGF_IMAGE_FORMAT_DEPTH32 ||
                                 info.format == NGF_IMAGE_FORMAT_DEPTH24_STENCIL8 ||
@@ -2675,11 +2676,14 @@ ngfi::value_or_ngferr<ngfvk_alloc> ngfvk_alloc::make(const ngf_image_info& info)
       .queueFamilyIndexCount = 0,
       .pQueueFamilyIndices   = NULL,
       .initialLayout         = VK_IMAGE_LAYOUT_UNDEFINED};
+  // Prefer lazily-allocated memory for transient attachments so they need no DRAM
+  // backing on tile-based GPUs. Preferred, not required: desktops have no such
+  // memory type, so VMA falls back to device-local instead of failing.
   VmaAllocationCreateInfo vma_alloc_info = {
       .flags          = 0u,
       .usage          = VMA_MEMORY_USAGE_GPU_ONLY,
       .requiredFlags  = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-      .preferredFlags = 0u,
+      .preferredFlags = is_transient ? VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT : 0u,
       .memoryTypeBits = 0u,
       .pool           = VK_NULL_HANDLE,
       .pUserData      = (void*)0x1};


### PR DESCRIPTION
maps to memoryless storage on Metal and lazily-allocated memory on Vulkan