### PR TITLE
[api] breaking API changes: removed ngf_unmap_buffer(), added ngf_buffer_get_mapped_ptr()

### DIFF
--- a/include/nicegraf-wrappers.h
+++ b/include/nicegraf-wrappers.h
@@ -185,16 +185,12 @@ static inline const attachment_descriptions* default_render_target_attachment_de
   return ngf_default_render_target_attachment_descs();
 }
 
-static inline void* buffer_map_range(unowned_buffer buf, size_t offset, size_t size) noexcept {
-  return ngf_buffer_map_range(buf, offset, size);
+static inline void* buffer_get_mapped_ptr(unowned_buffer buf, size_t offset) noexcept {
+  return ngf_buffer_get_mapped_ptr(buf, offset);
 }
 
 static inline void buffer_flush_range(unowned_buffer buf, size_t offset, size_t size) noexcept {
   ngf_buffer_flush_range(buf, offset, size);
-}
-
-static inline void buffer_unmap(unowned_buffer buf) noexcept {
-  ngf_buffer_unmap(buf);
 }
 
 static inline void finish() noexcept {
@@ -1053,10 +1049,9 @@ template<typename T> class uniform_multibuffer {
 
   void write(const T& data) {
     current_offset_  = (frame_)*aligned_per_frame_size_;
-    void* mapped_buf = ngf_buffer_map_range(buf_.get(), current_offset_, aligned_per_frame_size_);
+    void* mapped_buf = ngf_buffer_get_mapped_ptr(buf_.get(), current_offset_);
     memcpy(mapped_buf, (void*)&data, sizeof(T));
     ngf_buffer_flush_range(buf_.get(), 0, aligned_per_frame_size_);
-    ngf_buffer_unmap(buf_.get());
     frame_ = (frame_ + 1u) % nframes_;
   }
 

--- a/include/nicegraf.h
+++ b/include/nicegraf.h
@@ -2945,8 +2945,8 @@ void ngf_destroy_buffer(ngf_buffer buffer) NGF_NOEXCEPT;
  *
  * It is an error to bind a buffer that is currently mapped using any command. If a buffer that
  * needs to be bound is mapped, first call \ref ngf_buffer_flush_range to ensure any new data in the
- * mapped range becomes visible to the subsequent commands, then call \ref ngf_buffer_unmap. Writing
- * into any region that could be in use by previously submitted commands results in undefined
+ * mapped range becomes visible to the subsequent commands. Writing into any region that could be
+ * in use by previously submitted commands results in undefined
  * behavior.
  *
  * @param buf The handle to the buffer to be mapped.
@@ -2954,11 +2954,9 @@ void ngf_destroy_buffer(ngf_buffer buffer) NGF_NOEXCEPT;
  *               satisfy platform-specific alignment requirements. See, for example, \ref
  *               ngf_device_capabilities::uniform_buffer_offset_alignment and \ref
  *               ngf_device_capabilities::texel_buffer_offet_alignment.
- * @param size  The size of the mapped region, in bytes.
- * @param flags A combination of flags from \ref ngf_buffer_map_flags.
  * @return A pointer to the mapped memory, or NULL if the buffer could not be mapped.
  */
-void* ngf_buffer_map_range(ngf_buffer buf, size_t offset, size_t size) NGF_NOEXCEPT;
+void* ngf_buffer_get_mapped_ptr(ngf_buffer buf, size_t offset) NGF_NOEXCEPT;
 
 /**
  * \ingroup ngf
@@ -2971,18 +2969,6 @@ void* ngf_buffer_map_range(ngf_buffer buf, size_t offset, size_t size) NGF_NOEXC
  * @param size  The size of the flushed region, in bytes.
  */
 void ngf_buffer_flush_range(ngf_buffer buf, size_t offset, size_t size) NGF_NOEXCEPT;
-
-/**
- * \ingroup ngf
- *
- * Unmaps a previously mapped buffer.
- *
- * If multiple regions were mapped, all of them are unmapped. Any pointers returned by prior calls
- * to \ref ngf_buffer_map_range are invalidated.
- *
- * @param buf The buffer that needs to be unmapped.
- */
-void ngf_buffer_unmap(ngf_buffer buf) NGF_NOEXCEPT;
 
 /**
  * \ingroup ngf

--- a/misc/common/mesh-loader.cpp
+++ b/misc/common/mesh-loader.cpp
@@ -30,12 +30,11 @@
 namespace ngf_misc {
 
 static void read_into_mapped_buffer(FILE* f, ngf_buffer buf, size_t data_size) {
-  void* mapped_buffer_mem = ngf_buffer_map_range(buf, 0u, data_size);
+  void* mapped_buffer_mem = ngf_buffer_get_mapped_ptr(buf, 0u);
   const size_t read_elements =
       fread(mapped_buffer_mem, sizeof(char), data_size, f);
   NGF_MISC_ASSERT(read_elements == data_size);
   ngf_buffer_flush_range(buf, 0, data_size);
-  ngf_buffer_unmap(buf);
 }
 
 mesh load_mesh_from_file(const char* mesh_file_name, ngf_xfer_encoder xfenc) {

--- a/samples/03-uniform-buffers/uniform-buffers.cpp
+++ b/samples/03-uniform-buffers/uniform-buffers.cpp
@@ -170,13 +170,11 @@ void sample_draw_frame(
    * Write the updated values to the uniform buffer at current offset.
    * Map the range, write the data using memcpy, then flush and unmap.
    */
-  void* mapped_uniform_buffer_offset = ngf_buffer_map_range(
+  void* mapped_uniform_buffer_offset = ngf_buffer_get_mapped_ptr(
       state->uniform_buffer,
-      state->uniform_buffer_offset,
-      state->aligned_uniform_data_size);
+      state->uniform_buffer_offset);
   memcpy(mapped_uniform_buffer_offset, &state->uniform_values, sizeof(state->uniform_values));
   ngf_buffer_flush_range(state->uniform_buffer, 0, state->aligned_uniform_data_size);
-  ngf_buffer_unmap(state->uniform_buffer);
 
   /**
    * Record the rendering commands.

--- a/samples/05-cubemap/cubemap.cpp
+++ b/samples/05-cubemap/cubemap.cpp
@@ -91,7 +91,7 @@ void* sample_initialize(
           .storage_type = NGF_BUFFER_STORAGE_HOST_WRITEABLE,
           .buffer_usage = NGF_BUFFER_USAGE_XFER_SRC});
       mapped_staging_buffer =
-          (char*)ngf_buffer_map_range(staging_buffer.get(), 0, staging_buffer_size);
+          (char*)ngf_buffer_get_mapped_ptr(staging_buffer.get(), 0);
     } else if (face_width != width || face_height != height) {
       loge("All faces of the cubemap must have the same dimensions");
       return nullptr;
@@ -113,7 +113,6 @@ void* sample_initialize(
 
   /* Flush and unmap the staging buffer. */
   ngf_buffer_flush_range(staging_buffer.get(), 0, staging_buffer_size);
-  ngf_buffer_unmap(staging_buffer.get());
 
   /* Create the cubemap texture. */
   NGF_MISC_CHECK_NGF_ERROR(state->texture.initialize(ngf_image_info {

--- a/samples/06-vertex-attribs/vertex-attribs.cpp
+++ b/samples/06-vertex-attribs/vertex-attribs.cpp
@@ -240,15 +240,13 @@ void* sample_initialize(
   NGF_MISC_CHECK_NGF_ERROR(state->vertex_attrib_buffer.initialize(vertex_buffer_info));
   NGF_MISC_CHECK_NGF_ERROR(state->index_buffer.initialize(index_buffer_info));
   void* mapped_vertex_buffer =
-      ngf_buffer_map_range(vertex_staging_buffer.get(), 0u, vertex_staging_buffer_info.size);
+      ngf_buffer_get_mapped_ptr(vertex_staging_buffer.get(), 0u);
   void* mapped_index_buffer =
-      ngf_buffer_map_range(index_staging_buffer.get(), 0u, index_staging_buffer_info.size);
+      ngf_buffer_get_mapped_ptr(index_staging_buffer.get(), 0u);
   memcpy(mapped_vertex_buffer, vertex_attribs::vertex_data, vertex_staging_buffer_info.size);
   memcpy(mapped_index_buffer, vertex_attribs::index_data, index_staging_buffer_info.size);
   ngf_buffer_flush_range(vertex_staging_buffer.get(), 0, vertex_staging_buffer_info.size);
   ngf_buffer_flush_range(index_staging_buffer.get(), 0, index_staging_buffer_info.size);
-  ngf_buffer_unmap(vertex_staging_buffer.get());
-  ngf_buffer_unmap(index_staging_buffer.get());
   ngf_cmd_copy_buffer(
       xfer_encoder,
       vertex_staging_buffer.get(),
@@ -286,10 +284,9 @@ void* sample_initialize(
     .texel_format = NGF_IMAGE_FORMAT_RGBA32F
   };
   NGF_MISC_CHECK_NGF_ERROR(state->per_instance_data_view.initialize(instance_data_view_info));
-  auto mapped_per_instance_staging_buffer = (float*)ngf_buffer_map_range(
+  auto mapped_per_instance_staging_buffer = (float*)ngf_buffer_get_mapped_ptr(
       instance_data_staging_buffer.get(),
-      0,
-      instance_data_staging_buffer_info.size);
+      0);
   for (uint32_t r = 0; r < vertex_attribs::INSTANCES_GRID_SIZE; ++r) {
     for (uint32_t c = 0; c < vertex_attribs::INSTANCES_GRID_SIZE; ++c) {
       const uint32_t idx = r * (vertex_attribs::INSTANCES_GRID_SIZE) + c;
@@ -308,7 +305,6 @@ void* sample_initialize(
       instance_data_staging_buffer.get(),
       0,
       instance_data_staging_buffer_info.size);
-  ngf_buffer_unmap(instance_data_staging_buffer.get());
   ngf_cmd_copy_buffer(
       xfer_encoder,
       instance_data_staging_buffer,
@@ -340,7 +336,7 @@ void* sample_initialize(
       .storage_type = NGF_BUFFER_STORAGE_HOST_WRITEABLE,
       .buffer_usage = NGF_BUFFER_USAGE_XFER_SRC});
   auto mapped_staging_buffer =
-      (char*)ngf_buffer_map_range(staging_buffer.get(), 0, staging_buffer_size);
+      (char*)ngf_buffer_get_mapped_ptr(staging_buffer.get(), 0);
   std::vector<char> texture_rgba_data;
   texture_rgba_data.resize(staging_buffer_size);
   load_targa(
@@ -354,7 +350,6 @@ void* sample_initialize(
 
   /* Flush and unmap the staging buffer. */
   ngf_buffer_flush_range(staging_buffer.get(), 0, staging_buffer_size);
-  ngf_buffer_unmap(staging_buffer.get());
 
   /* Create the texture. */
   const uint32_t nmips =

--- a/samples/09-volume-rendering/volume-rendering.cpp
+++ b/samples/09-volume-rendering/volume-rendering.cpp
@@ -81,7 +81,7 @@ void* sample_initialize(
   NGF_MISC_CHECK_NGF_ERROR(staging_buffer.initialize(staging_buffer_info));
 
   /** Map the staging buffer and read the volume data directly into the memory. */
-  void* mapped_staging_buffer_ptr = ngf_buffer_map_range(staging_buffer, 0, staging_buffer_size);
+  void* mapped_staging_buffer_ptr = ngf_buffer_get_mapped_ptr(staging_buffer, 0);
   const uint64_t read_bytes =
       fread(mapped_staging_buffer_ptr, 1, staging_buffer_size, volume_data_file);
   if (ferror(volume_data_file)) {
@@ -94,9 +94,8 @@ void* sample_initialize(
   }
   fclose(volume_data_file);
 
-  /** Flush and unmap the staging buffer to prepare it for the upcoming transfer. */
+  /** Flush the staging buffer to prepare it for the upcoming transfer. */
   ngf_buffer_flush_range(staging_buffer, 0, staging_buffer_size);
-  ngf_buffer_unmap(staging_buffer);
 
   /** Prepare a 3D image. */
   const ngf_image_info img_info = {

--- a/samples/0b-compute-vertices/compute-vertices.cpp
+++ b/samples/0b-compute-vertices/compute-vertices.cpp
@@ -149,7 +149,7 @@ void* sample_initialize(
   NGF_MISC_CHECK_NGF_ERROR(staging_index_buffer.initialize(staging_index_buffer_info));
   NGF_MISC_CHECK_NGF_ERROR(state->index_buffer.initialize(index_buffer_info));
   auto mapped_staging_index_buffer = (uint32_t*)
-      ngf_buffer_map_range(staging_index_buffer.get(), 0u, staging_index_buffer_info.size);
+      ngf_buffer_get_mapped_ptr(staging_index_buffer.get(), 0u);
   uint32_t idx = 0u;
   for (uint32_t strip = 0u; strip < compute_verts::nverts_per_side - 1; ++strip) {
     for (uint32_t v = 0u; v < compute_verts::nverts_per_side; ++v) {
@@ -162,7 +162,6 @@ void* sample_initialize(
     mapped_staging_index_buffer[idx++] = ~0u;
   }
   ngf_buffer_flush_range(staging_index_buffer.get(), 0, staging_index_buffer_info.size);
-  ngf_buffer_unmap(staging_index_buffer.get());
   ngf_cmd_copy_buffer(
       xfer_encoder,
       staging_index_buffer.get(),

--- a/samples/common/imgui-backend.cpp
+++ b/samples/common/imgui-backend.cpp
@@ -123,10 +123,7 @@ ngf_imgui::ngf_imgui(
       NGF_BUFFER_USAGE_XFER_SRC};
   err = texture_data_.initialize(pbuffer_info);
   NGF_MISC_ASSERT(err == NGF_ERROR_OK);
-  void* mapped_texture_data = ngf_buffer_map_range(
-      texture_data_.get(),
-      0,
-      4 * (size_t)font_atlas_width * (size_t)font_atlas_height);
+  void* mapped_texture_data = ngf_buffer_get_mapped_ptr(texture_data_.get(), 0);
   memcpy(
       mapped_texture_data,
       font_atlas_bytes,
@@ -135,7 +132,6 @@ ngf_imgui::ngf_imgui(
       texture_data_.get(),
       0,
       4 * (size_t)font_atlas_width * (size_t)font_atlas_height);
-  ngf_buffer_unmap(texture_data_.get());
   const ngf_image_write img_write {
       .src_offset     = 0u,
       .dst_offset     = {0, 0, 0},
@@ -273,11 +269,10 @@ void ngf_imgui::record_rendering_commands(ngf_render_encoder enc) {
   ngf_buffer attrib_buffer = nullptr;
   ngf_create_buffer(&attrib_buffer_info, &attrib_buffer);
   attrib_buffer_.reset(attrib_buffer);
-  void* mapped_attrib_buffer = ngf_buffer_map_range(attrib_buffer, 0, attrib_buffer_info.size);
+  void* mapped_attrib_buffer = ngf_buffer_get_mapped_ptr(attrib_buffer, 0);
   NGF_MISC_ASSERT(mapped_attrib_buffer != nullptr);
   memcpy(mapped_attrib_buffer, vertex_data.data(), attrib_buffer_info.size);
   ngf_buffer_flush_range(attrib_buffer, 0, attrib_buffer_info.size);
-  ngf_buffer_unmap(attrib_buffer);
 
   ngf_buffer_info index_buffer_info {
       sizeof(ImDrawIdx) * index_data.size(),
@@ -286,11 +281,10 @@ void ngf_imgui::record_rendering_commands(ngf_render_encoder enc) {
   ngf_buffer index_buffer = nullptr;
   ngf_create_buffer(&index_buffer_info, &index_buffer);
   index_buffer_.reset(index_buffer);
-  void* mapped_index_buffer = ngf_buffer_map_range(index_buffer, 0, index_buffer_info.size);
+  void* mapped_index_buffer = ngf_buffer_get_mapped_ptr(index_buffer, 0);
   NGF_MISC_ASSERT(mapped_index_buffer != nullptr);
   memcpy(mapped_index_buffer, index_data.data(), index_buffer_info.size);
   ngf_buffer_flush_range(index_buffer, 0, index_buffer_info.size);
-  ngf_buffer_unmap(index_buffer);
 
   ngf_cmd_bind_index_buffer(
       enc,

--- a/samples/common/staging-image.cpp
+++ b/samples/common/staging-image.cpp
@@ -32,7 +32,7 @@ staging_image create_staging_image_from_tga(const char* file_name) {
       .size         = texture_size_bytes,
       .storage_type = NGF_BUFFER_STORAGE_HOST_READABLE_WRITEABLE,
       .buffer_usage = NGF_BUFFER_USAGE_XFER_SRC}));
-  void* mapped_staging_buf = ngf_buffer_map_range(staging_buf.get(), 0, texture_size_bytes);
+  void* mapped_staging_buf = ngf_buffer_get_mapped_ptr(staging_buf.get(), 0);
 
   /* Decode the loaded targa file, writing RGBA values directly into mapped memory. */
   load_targa(
@@ -43,9 +43,8 @@ staging_image create_staging_image_from_tga(const char* file_name) {
       &texture_width,
       &texture_height);
 
-  /* Flush and unmap the staging buffer. */
+  /* Flush the staging buffer. */
   ngf_buffer_flush_range(staging_buf.get(), 0, texture_size_bytes);
-  ngf_buffer_unmap(staging_buf.get());
 
   /* Count the number of mipmaps we'll have to generate for trilinear filtering.
      Note that we keep generating mip levels until both dimensions are reduced to 1.

--- a/source/ngf-mtl/impl.cpp
+++ b/source/ngf-mtl/impl.cpp
@@ -1783,22 +1783,19 @@ void ngfmtl_attachment_set_common(
   attachment->setStoreAction(get_mtl_store_action(store_op));
 }
 
-uint8_t* ngf_map_buffer(MTL::Buffer* buffer, size_t offset, [[maybe_unused]] size_t size) {
+uint8_t* ngf_buffer_get_mapped_ptr(MTL::Buffer* buffer, size_t offset) {
   return (uint8_t*)buffer->contents() + offset;
 }
 
-void* ngf_buffer_map_range(ngf_buffer buf, size_t offset, size_t size) NGF_NOEXCEPT {
+void* ngf_buffer_get_mapped_ptr(ngf_buffer buf, size_t offset) NGF_NOEXCEPT {
   buf->mapped_offset = offset;
-  return (void*)ngf_map_buffer(buf->mtl_buffer.get(), offset, size);
+  return (void*)ngf_buffer_get_mapped_ptr(buf->mtl_buffer.get(), offset);
 }
 
 void ngf_buffer_flush_range(
     [[maybe_unused]] ngf_buffer buf,
     [[maybe_unused]] size_t     offset,
     [[maybe_unused]] size_t     size) NGF_NOEXCEPT {
-}
-
-void ngf_buffer_unmap(ngf_buffer) NGF_NOEXCEPT {
 }
 
 ngf_error ngf_start_cmd_buffer(ngf_cmd_buffer cmd_buffer, ngf_frame_token) NGF_NOEXCEPT {

--- a/source/ngf-vk/impl.cpp
+++ b/source/ngf-vk/impl.cpp
@@ -6305,16 +6305,13 @@ extern "C" void ngf_destroy_buffer(ngf_buffer buffer) NGF_NOEXCEPT {
   }
 }
 
-extern "C" void* ngf_buffer_map_range(ngf_buffer buf, size_t offset, size_t) NGF_NOEXCEPT {
+extern "C" void* ngf_buffer_get_mapped_ptr(ngf_buffer buf, size_t offset) NGF_NOEXCEPT {
   buf->mapped_offset = offset;
   return (uint8_t*)buf->alloc.mapped_data + buf->mapped_offset;
 }
 
 extern "C" void ngf_buffer_flush_range(ngf_buffer buf, size_t offset, size_t size) NGF_NOEXCEPT {
   vmaFlushAllocation(_vk.allocator, buf->alloc.vma_alloc, buf->mapped_offset + offset, size);
-}
-
-extern "C" void ngf_buffer_unmap(ngf_buffer) NGF_NOEXCEPT {  // vk buffers are persistently mapped.
 }
 
 extern "C" ngf_error


### PR DESCRIPTION
Breaking Api change: removed ngf_unmap_buffer(), changed ngf_buffer_map_range() to ngf_buffer_get_mapped_ptr() and removed size parameter.

Both metal and vulkan implementations have persistently mapped host visible buffers and unmap was no-op before. Changed the samples to the new api. Updated docstrings and removed leftover @flags param too.

Built and tested samples on Windows 10 - Nvidia.
