### PR TITLE
[mtl] fix teardown crash from unretained device in ngf_context_t

### DIFF
--- a/source/ngf-mtl/impl.cpp
+++ b/source/ngf-mtl/impl.cpp
@@ -1561,7 +1561,7 @@ ngfi::maybe_ngfptr<ngf_context_t> ngf_context_t::make(const ngf_context_info& in
   auto ctx = ngfi::unique_ptr<ngf_context_t>::make();
   if (!ctx) { return NGF_ERROR_OUT_OF_MEM; }
 
-  ctx->device = MTL_DEVICE;
+  ctx->device = ngf_id<MTL::Device>::add_retain(MTL_DEVICE);
   ctx->queue  = ctx->device->newCommandQueue();
 
   if (info.swapchain_info) {


### PR DESCRIPTION
ngf_id's raw-pointer ctor adopts without retaining, so the context destructor released a shared device reference it never took